### PR TITLE
Demo: Build with RHEL Entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ More "official" information can be found in the following locations:
 4. Quarkus: [demos/4-quarkus](demos/4-quarkus/quarkus-demo.sh). An example of using
    [Quarkus](https://quarkus.io) to build a Java + NodeJS application with Shipwright, with a
    persistent cache to improve performance.
+5. Sharing Resources in Pods - coming soon!
+6. Building with RHEL Subscription Content: [demos/6-entitled-builds](demos/6-entitled-builds/demo.sh).
+   Note that this demo requires a cluster with a valid Red Hat subscription.

--- a/demos/6-entitled-builds/00-rhel-entitlement-sharedsecret.yaml
+++ b/demos/6-entitled-builds/00-rhel-entitlement-sharedsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: etc-pki-entitlement
+spec:
+  secretRef:
+    name: etc-pki-entitlement
+    namespace: openshift-config-managed

--- a/demos/6-entitled-builds/01-role-use-shared-secret.yaml
+++ b/demos/6-entitled-builds/01-role-use-shared-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: use-share-etc-pki-entitlement
+rules:
+  - apiGroups:
+      - sharedresource.openshift.io
+    resources:
+      - sharedsecrets
+    resourceNames:
+      - etc-pki-entitlement
+    verbs:
+      - use

--- a/demos/6-entitled-builds/02-rhel-entitlement-csi-role.yaml
+++ b/demos/6-entitled-builds/02-rhel-entitlement-csi-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: share-etc-pki-entitlement
+  namespace: openshift-config-managed
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - etc-pki-entitlement
+    verbs:
+      - get
+      - list
+      - watch

--- a/demos/6-entitled-builds/02-rhel-entitlement-csi-rolebinding.yaml
+++ b/demos/6-entitled-builds/02-rhel-entitlement-csi-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: share-etc-pki-entitlement
+  namespace: openshift-config-managed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: share-etc-pki-entitlement
+subjects:
+  - kind: ServiceAccount
+    name: csi-driver-shared-resource
+    namespace: openshift-builds

--- a/demos/6-entitled-builds/03-rolebinding-use-shared-secret.yaml
+++ b/demos/6-entitled-builds/03-rolebinding-use-shared-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: use-share-etc-pki-entitlement
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: use-share-etc-pki-entitlement
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+  - kind: ServiceAccount
+    name: builder

--- a/demos/6-entitled-builds/04-entitled-build.yaml
+++ b/demos/6-entitled-builds/04-entitled-build.yaml
@@ -1,0 +1,26 @@
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah-rhel
+spec:
+  source:
+    type: Git
+    git:
+      url: https://github.com/adambkaplan/builds-openshift-demos
+      revision: entitled-builds
+    contextDir: demos/6-entitled-builds/build
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+  paramValues:
+  - name: dockerfile
+    value: Containerfile
+  volumes:
+  - csi:
+      driver: csi.sharedresource.openshift.io
+      readOnly: true
+      volumeAttributes:
+        sharedSecret: etc-pki-entitlement
+    name: etc-pki-entitlement
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/buildah-entitlement/buildah-rhel:latest

--- a/demos/6-entitled-builds/build/Containerfile
+++ b/demos/6-entitled-builds/build/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+RUN dnf --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms install \
+    cloud-init \ 
+    nss_wrapper \
+    uid_wrapper -y && \
+    dnf clean all -y

--- a/demos/6-entitled-builds/demo.sh
+++ b/demos/6-entitled-builds/demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# shellcheck source-path=lib
+. ../../lib/demo-magic.sh
+
+oc new-project buildah-entitlement
+oc create imagestream buildah-rhel
+clear
+
+p "Suppose our build needs to install RHEL packages:"
+pe "cat build/Containerfile"
+p "With Builds 1.2, we can use the cluster's subscription to install RHEL content!"
+clear
+
+p "To access the subscription, a cluster admin first needs to share it using a SharedSecret object."
+cat 00-rhel-entitlement-sharedsecret.yaml
+pe "oc apply -f 00-rhel-entitlement-sharedsecret.yaml"
+wait
+p "The cluster admin should also create a ClusterRoleBinding to let others use the SharedSecret."
+cat 01-role-use-shared-secret.yaml
+pe "oc apply -f 01-role-use-shared-secret.yaml"
+wait
+clear
+
+p "Next, the cluster admin needs to grant the Shared Resource CSI Driver permission to access the underlying Secret object."
+cat 02-rhel-entitlement-csi-role.yaml
+echo "---"
+cat 02-rhel-entitlement-csi-rolebinding.yaml
+pe "oc apply -f 02-rhel-entitlement-csi-role.yaml"
+pe "oc apply -f 02-rhel-entitlement-csi-rolebinding.yaml"
+wait
+clear
+
+p "After the CSI driver is granted the right RBAC, the service accounts that run the build need permission to use the SharedSecret."
+p "This can be done by anyone with 'admin' permissions in the namespace."
+cat 03-rolebinding-use-shared-secret.yaml
+pe "oc apply -f 03-rolebinding-use-shared-secret.yaml"
+wait
+clear
+
+p "Finally, we configure a build to mount the SharedSecret into the build, and run it!"
+cat 04-entitled-build.yaml
+pe "oc apply -f 04-entitled-build.yaml"
+pe "shp build run buildah-rhel -F"
+wait
+p "Our build ran and successfully installed the RHEL packages!"
+wait
+clear
+
+oc delete project buildah-entitlement
+oc delete rolebinding share-etc-pki-entitlement -n openshift-config-managed
+oc delete role share-etc-pki-entitlement -n openshift-config-managed
+oc delete clusterrole use-share-etc-pki-entitlement
+oc delete sharedsecret etc-pki-entitlement


### PR DESCRIPTION
This contains the manifests and code needed to build a container that installs RHEL subscription content on OpenShift. It takes advantage of the Shared Resource CSI Driver and recent improvements to consuming entitlements in RHEL 9.3+.

Notable is the additional RBAC that needs to be granted to the Shared Resource CSI driver for each shared object. This is an area for future improvement.