### PR TITLE
feat: Demo Cloud Native Buildpacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+auth.json

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ More "official" information can be found in the following locations:
    Builds for OpenShift installed, run this demo script first.
 1. Build Strategies: [demos/1-build-strategies](demos/1-build-strategies/build-strategies-demo.sh).
    This demos how to build with `source-to-image` and `buildah` build strategies.
-2. Cloud Native Buildpacks - coming soon!
+2. Cloud Native Buildpacks - [demos/2-cnb](demos/2-cnb/demo.sh). This is a preview of how to run a
+   build with Cloud Native Buildpacks. Note that for this demo to work, you need to provide a pull
+   secret for `docker.io` named `dockerhub` and add it to your cluster.
 3. Build Volumes: [demos/3-build-volumes](demos/3-build-volumes/build-volumes-demo.sh). This demos
    how to create a custom [BuildStrategy](https://shipwright.io/docs/build/buildstrategies/#overview)
    and add a [persistent volume](https://shipwright.io/docs/build/build/#defining-volumes) for

--- a/demos/2-cnb/00-buildpacks-build-strategy.yaml
+++ b/demos/2-cnb/00-buildpacks-build-strategy.yaml
@@ -1,0 +1,289 @@
+apiVersion: shipwright.io/v1beta1
+kind: ClusterBuildStrategy
+metadata:
+  name: buildpacks
+spec:
+  volumes:
+    - name: certificate-registry
+      emptyDir: {}
+      overridable: true
+    - name: creds-ws
+      emptyDir: {}
+      overridable: true
+    - name: kaniko-dir
+      emptyDir: {}
+    - name: platform-env
+      emptyDir: {}
+    - name: layers-dir
+      emptyDir: {}
+    - name: empty-dir
+      emptyDir: {}
+    - name: cache-dir
+      emptyDir: {}
+      overridable: true
+  parameters:
+    - name: certificate-path
+      description: Path to self signed certificate(s)
+      default: "/selfsigned-certificates"
+    - name: CNB_PLATFORM_API
+      description: Platform API Version supported
+      default: ""
+    - name: CNB_BUILDER_IMAGE
+      description: Builder image containing the buildpacks
+      default: ""
+    - name: CNB_LIFECYCLE_IMAGE
+      description: The image to use when executing Lifecycle phases.
+      default: ""
+    - name: CNB_RUN_IMAGE
+      description: Reference to a run image to use.
+      default: ""
+    - name: CNB_BUILD_IMAGE
+      description: Reference to the current build image in an OCI registry (if used <kaniko-dir> must be provided)
+      default: ""
+    - name: CNB_LOG_LEVEL
+      description: Logging level
+      default: "info"
+    - name: APP_IMAGE
+      description: The name of where to store the app image.
+    - name: CACHE_IMAGE
+      description: The name of the persistent app cache image (if no cache workspace is provided).
+      default: ""
+    - name: CACHE_DIR_NAME
+      description: Directory to cache files
+      default: cache
+    - name: PROCESS_TYPE
+      description: The default process type to set on the image.
+      default: ""
+    - name: SOURCE_SUBPATH
+      description: A subpath within the `source` input where the source to build is located.
+      default: ""
+    - name: ENV_VARS
+      type: array
+      description: Environment variables to set during _build-time_.
+      defaults: []
+    - name: PLATFORM_DIR
+      description: The name of the platform directory.
+      default: empty-dir
+    - name: CNB_USER_ID
+      description: The user ID of the builder image user.
+      default: "1001"
+    - name: CNB_GROUP_ID
+      description: The group ID of the builder image user.
+      default: "1000"
+    - name: CNB_INSECURE_REGISTRIES
+      description: List of registries separated by a comma having a self-signed certificate where TLS verification will be skipped.
+    - name: USER_HOME
+      description: Absolute path to the user's home directory.
+      default: /tekton/home
+    - # TODO: Should be defined using ENV_VARS. To be reviewed
+      name: BP_NATIVE_IMAGE
+      description: Whether to build a native image from the application. Defaults to false.
+      default: "false"
+    - # TODO: Should be defined using ENV_VARS. To be reviewed
+      name: BP_MAVEN_BUILT_ARTIFACT
+      description: Configure the built application artifact explicitly. Supersedes $BP_MAVEN_BUILT_MODULE Defaults to target/*.[ejw]ar. Can match a single file, multiple files or a directory. Can be one or more space separated patterns.
+      default: "target/*.[ejw]ar"
+    - # TODO: Should be defined using ENV_VARS. To be reviewed
+      name: BP_MAVEN_BUILD_ARGUMENTS
+      description: Configure the arguments to pass to Maven. Defaults to -Dmaven.test.skip=true --no-transfer-progress package. --batch-mode will be prepended to the argument list in environments without a TTY.
+      default: "-Dmaven.test.skip=true --no-transfer-progress package"
+  steps:
+    - name: prepare
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.6
+      command: ["/bin/bash"]
+      args:
+        - -c
+        - |
+          set -e
+
+          # TODO: To be reviewed
+          echo "> Creating the cache directory if it is not empty"
+          if [ ! -d "$DIRECTORY" ]; then
+            echo "> Creating cache: /layers/$(params.CACHE_DIR_NAME)"
+            mkdir -p /layers/$(params.CACHE_DIR_NAME)
+            chown -R "$(params.CNB_USER_ID):$(params.CNB_GROUP_ID)" /layers/$(params.CACHE_DIR_NAME)
+          fi
+
+          # TODO: To be reviewed as shipwright don't support like Tekton workspaces
+          #if [[ "$(workspaces.cache.bound)" == "true" ]]; then
+          #  echo "> Setting permissions on '$(workspaces.cache.path)'..."
+          #  chown -R "$(params.CNB_USER_ID):$(params.CNB_GROUP_ID)" "$(workspaces.cache.path)"
+          #fi
+
+          echo "Creating .docker folder"
+          mkdir -p "/tekton/home/.docker"
+
+          for path in "/tekton/home" "/tekton/home/.docker" "/layers" "$(workspaces.source.path)"; do
+            echo "> Setting permissions on '$path'..."
+            chown -R "$(params.CNB_USER_ID):$(params.CNB_GROUP_ID)" "$path"
+          done
+
+          echo "> Parsing additional configuration..."
+          parsing_flag=""
+          envs=()
+          for arg in "$@"; do
+              if [[ "$arg" == "--env-vars" ]]; then
+                  echo "-> Parsing env variables..."
+                  parsing_flag="env-vars"
+              elif [[ "$parsing_flag" == "env-vars" ]]; then
+                  envs+=("$arg")
+              fi
+          done
+
+          echo "> Processing any environment variables..."
+          ENV_DIR="/platform/env"
+
+          echo "--> Creating 'env' directory: $ENV_DIR"
+          mkdir -p "$ENV_DIR"
+
+          for env in "${envs[@]}"; do
+              IFS='=' read -r key value string <<< "$env"
+              if [[ "$key" != "" && "$value" != "" ]]; then
+                  path="${ENV_DIR}/${key}"
+                  echo "--> Writing ${path}..."
+                  echo -n "$value" > "$path"
+              fi
+          done
+        # That's the separator between the shell script and its args
+        - --
+        - --env-vars
+        - $(params.ENV_VARS[*])
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: empty-dir #name: --> DON'T WORK : $(params.PLATFORM_DIR)
+          mountPath: /platform
+        - name: cache-dir #name: --> DON'T WORK : $(params.CACHE_DIR_NAME)
+          mountPath: /tmp/cache
+    - name: analyze
+      image: $(params.CNB_BUILDER_IMAGE)
+      command: ["/cnb/lifecycle/analyzer"]
+      args:
+        - "-log-level=$(params.CNB_LOG_LEVEL)"
+        - "-layers=/layers"
+        - "-run-image=$(params.CNB_RUN_IMAGE)"
+        - "-cache-image=$(params.CACHE_IMAGE)"
+        - "-uid=$(params.CNB_USER_ID)"
+        - "-gid=$(params.CNB_GROUP_ID)"
+        - "-insecure-registry=$(params.CNB_INSECURE_REGISTRIES)"
+        - "$(params.APP_IMAGE)"
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.CNB_PLATFORM_API)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+
+    - name: detect
+      image: $(params.CNB_BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/detector"]
+      args:
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
+        - "-group=/layers/group.toml"
+        - "-plan=/layers/plan.toml"
+        - "-platform=$(params.PLATFORM_DIR)"
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.CNB_PLATFORM_API)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: empty-dir # Hard coded the name as substitution do not work: $(params.PLATFORM_DIR)
+          mountPath: /platform
+        - name: empty-dir
+          mountPath: /tekton/home
+
+    - name: restore
+      image: $(params.CNB_BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/restorer"]
+      args:
+        - "-log-level=$(params.CNB_LOG_LEVEL)"
+        - "-build-image=$(params.CNB_BUILD_IMAGE)"
+        - "-group=/layers/group.toml"
+        - "-layers=/layers"
+        - "-cache-dir=/layers/$(params.CACHE_DIR_NAME)"
+        - "-cache-image=$(params.CACHE_IMAGE)"
+        - "-uid=$(params.CNB_USER_ID)"
+        - "-gid=$(params.CNB_GROUP_ID)"
+        - "-insecure-registry=$(params.CNB_INSECURE_REGISTRIES)"
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.CNB_PLATFORM_API)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: kaniko-dir
+          mountPath: /kaniko
+        - name: cache-dir
+          mountPath: /tmp/cache #name: --> DON'T WORK : $(params.CACHE_DIR_NAME)
+
+    - name: extender
+      image: $(params.CNB_BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/extender"]
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.CNB_PLATFORM_API)
+      args:
+        - "-log-level=$(params.CNB_LOG_LEVEL)"
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
+        - "-generated=/layers/generated"
+        - "-uid=$(params.CNB_USER_ID)"
+        - "-gid=$(params.CNB_GROUP_ID)"
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        capabilities:
+          add:
+            - "SYS_ADMIN"
+            - "SETFCAP"
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: kaniko-dir
+          mountPath: /kaniko
+        - name: empty-dir
+          mountPath: /tekton/home
+
+    - name: export
+      image: $(params.CNB_BUILDER_IMAGE)
+      imagePullPolicy: Always
+      command: ["/cnb/lifecycle/exporter"]
+      args:
+        - "-log-level=$(params.CNB_LOG_LEVEL)"
+        - "-app=$(workspaces.source.path)/$(params.SOURCE_SUBPATH)"
+        - "-layers=/layers"
+        - "-group=/layers/group.toml"
+        - "-cache-dir=/layers/$(params.CACHE_DIR_NAME)"
+        - "-cache-image=$(params.CACHE_IMAGE)"
+        - "-report=/layers/report.toml"
+        - "-process-type=$(params.PROCESS_TYPE)"
+        - "-uid=$(params.CNB_USER_ID)"
+        - "-gid=$(params.CNB_GROUP_ID)"
+        - "-insecure-registry=$(params.CNB_INSECURE_REGISTRIES)"
+        - "$(params.APP_IMAGE)"
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.CNB_PLATFORM_API)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: cache-dir
+          mountPath: /tmp/cache #name: --> DON'T WORK : $(params.CACHE_DIR_NAME)
+        - mountPath: /selfsigned-certificates
+          name: certificate-registry
+          readOnly: true
+
+    - name: results
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.6
+      command: ["/bin/bash"]
+      args:
+        - -c
+        - |
+          set -e
+          cat /layers/report.toml | grep "digest" | cut -d'"' -f2 | cut -d'"' -f2 | tr -d '\n' > $(results.shp-image-digest.path)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers

--- a/demos/2-cnb/01-pipeline-privileged-scc-rolebinding.yaml
+++ b/demos/2-cnb/01-pipeline-privileged-scc-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-privileged-scc
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+roleRef:
+  kind: ClusterRole
+  name: "system:openshift:scc:privileged"
+  apiGroup: rbac.authorization.k8s.io

--- a/demos/2-cnb/02-build.yaml
+++ b/demos/2-cnb/02-build.yaml
@@ -1,0 +1,52 @@
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: quarkus-hello
+  labels:
+    app: quarkus-hello
+    app.kubernetes.io/component: quarkus-hello
+    app.kubernetes.io/instance: quarkus-hello
+    app.kubernetes.io/name: quarkus-hello
+    app.kubernetes.io/part-of: quarkus-hello-app
+    app.openshift.io/runtime: java
+    app.openshift.io/runtime-version: openjdk-17-ubi8
+spec:
+  source:
+    type: Git
+    git:
+      url: https://github.com/quarkusio/quarkus-quickstarts
+      revision: "3.22"
+    contextDir: getting-started
+  paramValues:
+    - name: SOURCE_SUBPATH
+      value: getting-started
+    - name: CNB_PLATFORM_API
+      value: "0.13"
+    - name: CNB_BUILDER_IMAGE
+      value: docker.io/paketobuildpacks/builder-ubi8-base:0.1.1
+    - name: CNB_LIFECYCLE_IMAGE
+      value: docker.io/buildpacksio/lifecycle:0.20.9
+    - name: CNB_INSECURE_REGISTRIES
+      value: image-registry.openshift-image-registry.svc:5000
+    - name: CNB_USER_ID
+      value: "1002"
+    - name: CNB_GROUP_ID
+      value: "1000"
+    - name: CNB_RUN_IMAGE
+      value: docker.io/paketobuildpacks/run-ubi8-base:0.0.114
+    - name: CNB_BUILD_IMAGE
+      value: docker.io/paketobuildpacks/build-ubi8-base:0.0.114
+    - name: APP_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/ubi-buildpacks/quarkus-hello
+    - name: PROCESS_TYPE
+      value: ""
+    - name: ENV_VARS
+      values:
+        - value: BP_JVM_VERSION=21
+  strategy:
+    name: buildpacks
+    kind: ClusterBuildStrategy
+  output:
+    image: image-registry.openshift-image-registry.svc:5000/ubi-buildpacks/quarkus-hello:latest
+  volumes:
+    - name: creds-ws

--- a/demos/2-cnb/03-deployment.yaml
+++ b/demos/2-cnb/03-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+    app.openshift.io/route-disabled: "false"
+    app.openshift.io/vcs-ref: ""
+    app.openshift.io/vcs-uri: https://github.com/quarkusio/quarkus-quickstarts
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"quarkus-hello:latest","namespace":"ubi-buildpacks"},"fieldPath":"spec.template.spec.containers[?(@.name==\"quarkus-hello\")].image","paused":"false"}]'
+  labels:
+    app: quarkus-hello
+    app.kubernetes.io/component: quarkus-hello
+    app.kubernetes.io/instance: quarkus-hello
+    app.kubernetes.io/name: quarkus-hello
+    app.kubernetes.io/part-of: quarkus-hello-app
+    app.openshift.io/runtime: java
+    app.openshift.io/runtime-version: openjdk-17-ubi8
+  name: quarkus-hello
+  namespace: ubi-buildpacks
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: quarkus-hello
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: quarkus-hello
+        deployment: quarkus-hello
+    spec:
+      containers:
+      - image: image-registry.openshift-image-registry.svc:5000/ubi-buildpacks/quarkus-hello:latest
+        imagePullPolicy: Always
+        name: quarkus-hello
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/demos/2-cnb/04-service.yaml
+++ b/demos/2-cnb/04-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-ref: ""
+    app.openshift.io/vcs-uri: https://github.com/quarkusio/quarkus-quickstarts
+  labels:
+    app: quarkus-hello
+    app.kubernetes.io/component: quarkus-hello
+    app.kubernetes.io/instance: quarkus-hello
+    app.kubernetes.io/name: quarkus-hello
+    app.kubernetes.io/part-of: quarkus-hello-app
+    app.openshift.io/runtime: java
+    app.openshift.io/runtime-version: openjdk-17-ubi8
+  name: quarkus-hello
+  namespace: ubi-buildpacks
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: 8443-tcp
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: quarkus-hello
+    deployment: quarkus-hello
+  sessionAffinity: None
+  type: ClusterIP

--- a/demos/2-cnb/05-route.yaml
+++ b/demos/2-cnb/05-route.yaml
@@ -1,0 +1,28 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    app.openshift.io/vcs-ref: ""
+    app.openshift.io/vcs-uri: https://github.com/quarkusio/quarkus-quickstarts
+    openshift.io/host.generated: "true"
+  labels:
+    app: quarkus-hello
+    app.kubernetes.io/component: quarkus-hello
+    app.kubernetes.io/instance: quarkus-hello
+    app.kubernetes.io/name: quarkus-hello
+    app.kubernetes.io/part-of: quarkus-hello-app
+    app.openshift.io/runtime: java
+    app.openshift.io/runtime-version: openjdk-17-ubi8
+  name: quarkus-hello
+  namespace: ubi-buildpacks
+spec:
+  port:
+    targetPort: 8080-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: quarkus-hello
+    weight: 100
+  wildcardPolicy: None

--- a/demos/2-cnb/demo.sh
+++ b/demos/2-cnb/demo.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# shellcheck source-path=lib
+. ../../lib/demo-magic.sh
+
+oc new-project ubi-buildpacks
+oc apply -f 00-buildpacks-build-strategy.yaml
+oc apply -f 01-pipeline-privileged-scc-rolebinding.yaml
+oc create secret generic dockerhub \
+    --from-file=auth.json \
+    --type=kubernetes.io/podmanconfigjson
+oc secrets link pipeline dockerhub --for=pull
+oc secrets link builder dockerhub --for=pull
+oc secrets link default dockerhub --for=pull
+oc create imagestream quarkus-hello
+oc apply -f 02-build.yaml
+oc apply -f 03-deployment.yaml
+oc apply -f 04-service.yaml
+oc apply -f 05-route.yaml
+clear
+
+p "Coming Soon to Builds for OpenShift - Cloud Native Buildpacks!"
+pe "oc get clusterbuildstrategies"
+clear
+
+p "Let's build a Quarkus application using UBI Buildpacks!"
+cat 02-build.yaml
+wait
+clear
+
+pe "shp build run quarkus-hello -F"
+wait
+clear
+
+# oc delete project ubi-buildpacks
+# oc delete clusterbuildstrategy buildpacks


### PR DESCRIPTION
Demo of using CNB to build a Quarkus application. Note that this is tested on Builds 1.4, which does not include the buildpacks strategy by default. It makes use of the Paketo UBI container images, but any CNB builder image should be supported.